### PR TITLE
Native window tweak

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,19 +2,32 @@
 const electron = require('electron');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
+const Menu = electron.Menu;
 
 let mainWindow = null;
 
-app.on('window-all-closed', function(){
-    app.quit();
+if(process.platform == 'darwin'){
+  Menu.setApplicationMenu(new Menu());
+  // Delete the menu items on Mac OS X devices.
+}
+
+app.on('window-all-closed', function() {
+  app.quit();
 });
 
 app.on('ready', function() {
-    mainWindow = new BrowserWindow({width: 1280, height: 800});
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    minWidth: 992,
+    minHeight: 310
+  });
 
-    mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.setMenu(null); // Diable the Native Menu on Windows, use Context Menu inside the HTML.
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.show();
 
-    mainWindow.on('closed', function(){
-        mainWindow = null;
-    });
+  mainWindow.on('closed', function() {
+    mainWindow = null;
+  });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -19,13 +19,14 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
-    minWidth: 992,
+    minWidth: 1000,
     minHeight: 310
   });
 
   mainWindow.setMenu(null); // Diable the Native Menu on Windows, use Context Menu inside the HTML.
   mainWindow.loadURL('file://' + __dirname + '/index.html');
   mainWindow.show();
+  mainWindow.maximize();
 
   mainWindow.on('closed', function() {
     mainWindow = null;

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
-    minWidth: 1000,
+    minWidth: 1100,
     minHeight: 310
   });
 


### PR DESCRIPTION
1. Delete all application menu items on OS X.
2. Disable the native menu on Windows and Linux.
3. Fix some small display problem caused by inaccurate DPI enlarging system on Windows.
4. Prompt and maximize the window when it starts.
5. Fix tabs.
